### PR TITLE
Refactor VsMefContainerBuilder.cs

### DIFF
--- a/VSEmbed.Roslyn/Dev14KeyProcessor.cs
+++ b/VSEmbed.Roslyn/Dev14KeyProcessor.cs
@@ -25,23 +25,18 @@ namespace VSEmbed.Roslyn {
 		readonly ILightBulbBroker lightBulbBroker;
 		readonly ISuggestedActionCategoryRegistryService suggestedActionCategoryRegistryService;
 		readonly ISmartTagBroker smartTagBroker;
-		readonly IPeekBroker peekBroker;
 
-		public Dev14KeyProcessor(IWpfTextView wpfTextView, ILightBulbBroker lightBulbBroker, ISuggestedActionCategoryRegistryService suggestedActionCategoryRegistryService, ISmartTagBroker smartTagBroker, IPeekBroker peekBroker) {
+		public Dev14KeyProcessor(IWpfTextView wpfTextView, ILightBulbBroker lightBulbBroker, ISuggestedActionCategoryRegistryService suggestedActionCategoryRegistryService, ISmartTagBroker smartTagBroker) {
 			this.wpfTextView = wpfTextView;
 			this.lightBulbBroker = lightBulbBroker;
 			this.suggestedActionCategoryRegistryService = suggestedActionCategoryRegistryService;
 			this.smartTagBroker = smartTagBroker;
-			this.peekBroker = peekBroker;
 
 			AddShortcuts();
 		}
 
 		void AddShortcuts() {
 			AddControlCommand(Key.OemPeriod, TryShowSuggestedActions);
-
-			// Alt+regular keys doesn't trigger this at all
-			AddCommand(Key.F12, TryPeek);
 		}
 
 		bool TryShowSuggestedActions() {
@@ -64,11 +59,8 @@ namespace VSEmbed.Roslyn {
 			session.State = SmartTagState.Expanded;
 			return true;
 		}
-
-		bool TryPeek() {
-			return peekBroker.TriggerPeekSession(wpfTextView, PredefinedPeekRelationships.Definitions.Name) != null;
-		}
 	}
+
 	[Export(typeof(IChainedKeyProcessorProvider))]
 	[ContentType("text")]
 	[TextViewRole(PredefinedTextViewRoles.Interactive)]
@@ -83,9 +75,6 @@ namespace VSEmbed.Roslyn {
 		[Import]
 		public ISuggestedActionCategoryRegistryService SuggestedActionCategoryRegistryService { get; set; }
 
-		[Import]
-		public IPeekBroker PeekBroker { get; set; }
-
 		//I'm limiting us to a single keyprocessor and therefore a single wpfTextView
 		private Dev14KeyProcessor keyProcessor = null;
 
@@ -93,7 +82,7 @@ namespace VSEmbed.Roslyn {
 		{
 			if (keyProcessor == null)
 			{
-				return new Dev14KeyProcessor(wpfTextView, LightBulbBroker, SuggestedActionCategoryRegistryService, SmartTagBroker, PeekBroker);
+				return new Dev14KeyProcessor(wpfTextView, LightBulbBroker, SuggestedActionCategoryRegistryService, SmartTagBroker);
 			}
 
 			return keyProcessor;

--- a/VSEmbed.Roslyn/RoslynKeyProcessor.cs
+++ b/VSEmbed.Roslyn/RoslynKeyProcessor.cs
@@ -158,7 +158,6 @@ namespace VSEmbed.Roslyn {
 			AddIntCommand(ModifierKeys.Control | ModifierKeys.Shift, Key.Z, "ExecuteRedo", 1);
 
 			// TODO: Export IDocumentNavigationService to allow F12
-			// TODO: Invoke peek from IntellisenseCommandFilter
 			// TODO: ExecuteCommentBlock, ExecuteFormatSelection, ExecuteFormatDocument, ExecuteInsertSnippet, ExecuteInsertComment, ExecuteSurroundWith
 		}
 		#endregion

--- a/VSEmbed/VSEmbed.csproj
+++ b/VSEmbed/VSEmbed.csproj
@@ -23,7 +23,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <DocumentationFile>bin\Debug\VSEmbed.XML</DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/VSEmbed/VsMefContainerBuilder.cs
+++ b/VSEmbed/VsMefContainerBuilder.cs
@@ -1,20 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Windows;
-using System.Windows.Media;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Composition;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Text.Operations;
-using Microsoft.VisualStudio.Text.Storage;
-using Microsoft.VisualStudio.Utilities;
 
 using MEFv1 = System.ComponentModel.Composition;
 using MEFv3 = Microsoft.VisualStudio.Composition;

--- a/VSEmbed/VsMefContainerBuilder.cs
+++ b/VSEmbed/VsMefContainerBuilder.cs
@@ -31,13 +31,6 @@ namespace VSEmbed
 			this.catalog = catalog;
 		}
 
-		internal static VsMefContainerBuilder Create()
-		{
-			return new VsMefContainerBuilder(MEFv3.ComposableCatalog.Create(Resolver.DefaultInstance))
-				// Needed for ExportMetadataViewInterfaceEmitProxy to support editor metadata types.
-				.WithFilteredCatalogs(Assembly.Load("Microsoft.VisualStudio.Composition.Configuration")); ;
-		}
-
 		#region Export Exclusion
 		static readonly HashSet<string> excludedTypes = new HashSet<string> {
 			// This uses IVsUIShell, which I haven't implemented, to show dialog boxes.
@@ -181,7 +174,11 @@ namespace VSEmbed
 		///<summary>Creates a builder prepopulated with the editor and Roslyn catalogs.</summary>
 		public static VsMefContainerBuilder CreateDefault()
 		{
-			return Create().WithEditorCatalogs().WithRoslynCatalogs();
+			var containerBuilder = new VsMefContainerBuilder(MEFv3.ComposableCatalog.Create(Resolver.DefaultInstance))
+				// Needed for ExportMetadataViewInterfaceEmitProxy to support editor metadata types.
+				.WithFilteredCatalogs(Assembly.Load("Microsoft.VisualStudio.Composition.Configuration"));
+			
+			return containerBuilder.WithEditorCatalogs().WithRoslynCatalogs();
 		}
 
 		class ComponentModel : IComponentModel

--- a/VSEmbed/VsMefContainerBuilder.cs
+++ b/VSEmbed/VsMefContainerBuilder.cs
@@ -42,7 +42,7 @@ namespace VSEmbed
 			// SLaks: Needed for VisualStudioWaitIndicator & probably others
 			"Microsoft.VisualStudio.Editor.Implementation",
 
-			// SLaks: Needed for IVsHierarchyItemManager, used by peek providers
+			//// SLaks: Needed for IVsHierarchyItemManager, used by peek providers
 			"Microsoft.VisualStudio.Shell.TreeNavigation.HierarchyProvider"
 		};
 

--- a/VSEmbed/VsMefContainerBuilder.cs
+++ b/VSEmbed/VsMefContainerBuilder.cs
@@ -29,9 +29,6 @@ namespace VSEmbed
 			// JaredPar: Core editor components
 			"Microsoft.VisualStudio.Platform.VSEditor",
 
-			// JaredPar: Not entirely sure why this is suddenly needed
-			"Microsoft.VisualStudio.Text.Internal",
-
 			// JaredPar: Must include this because several editor options are actually stored as exported information 
 			// on this DLL.  Including most importantly, the tabsize information
 			"Microsoft.VisualStudio.Text.Logic",

--- a/VSEmbed/VsServiceProvider.cs
+++ b/VSEmbed/VsServiceProvider.cs
@@ -74,9 +74,6 @@ namespace VSEmbed {
 					// Used by Dev14's VsImageLoader, which is needed for Roslyn IntelliSense
 					{ typeof(SVsAppId).GUID, new SimpleVsAppId() },
 
-					// Used by DocumentPeekResult; service is SVsUIThreadInvokerPrivate
-					{ new Guid("72FD1033-2341-4249-8113-EF67745D84EA"), new AppDispatcherInvoker() },
-
 					// Used by KeyBindingHelper.GetKeyBinding, which is used by VSLightBulbPresenterStyle.
 					{ typeof(SDTE).GUID, new StubDTE() },
 


### PR DESCRIPTION
This removes the `V1` implementation of MEF and combines `V3` and `VsMefContainerBuilder` into a single class.

I also inlined some methods and organized the file a bit to help me better understand how it works.