### PR TITLE
Explicitly list all MEF DLLs we're interested in.

### DIFF
--- a/VSEmbed/VsMefContainerBuilder.cs
+++ b/VSEmbed/VsMefContainerBuilder.cs
@@ -54,7 +54,6 @@ namespace VSEmbed
 
 		public static VsMefContainerBuilder CreateDefault()
 		{
-			//var assemblies = 
 			var roslynFiles = new string[] {
 				@"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\PrivateAssemblies\Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll",
 				@"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\PrivateAssemblies\Microsoft.CodeAnalysis.CSharp.Features.dll",

--- a/VSEmbed/VsMefContainerBuilder.cs
+++ b/VSEmbed/VsMefContainerBuilder.cs
@@ -162,16 +162,11 @@ namespace VSEmbed
 			var containerBuilder = new VsMefContainerBuilder(MEFv3.ComposableCatalog.Create(Resolver.DefaultInstance))
 				// Needed for ExportMetadataViewInterfaceEmitProxy to support editor metadata types.
 				.WithFilteredCatalogs(Assembly.Load("Microsoft.VisualStudio.Composition.Configuration"));
-			
-			return containerBuilder.WithEditorCatalogs().WithRoslynCatalogs();
-		}
 
-		///<summary>Creates a new builder, including catalogs for the core editor services.</summary>
-		public VsMefContainerBuilder WithEditorCatalogs()
-		{
-			return WithFilteredCatalogs(EditorComponents.Select(c => Assembly.Load(c + VsFullNameSuffix)))
-				  .WithFilteredCatalogs(UndoComponents.Select(n=>Assembly.Load(n)))
-				  .WithFilteredCatalogs(typeof(VsMefContainerBuilder).Assembly);
+			return containerBuilder.WithFilteredCatalogs(EditorComponents.Select(c => Assembly.Load(c + VsFullNameSuffix)))
+				  .WithFilteredCatalogs(UndoComponents.Select(n => Assembly.Load(n)))
+				  .WithFilteredCatalogs(typeof(VsMefContainerBuilder).Assembly)
+				  .WithRoslynCatalogs();
 		}
 
 		class ComponentModel : IComponentModel

--- a/VSEmbed/VsMefContainerBuilder.cs
+++ b/VSEmbed/VsMefContainerBuilder.cs
@@ -128,9 +128,9 @@ namespace VSEmbed
 			// Necessary (together with ugly Reflection) to use WorkCoordinator.HighPriorityProcessor.
 			types.Add(Type.GetType("Microsoft.VisualStudio.LanguageServices.Implementation.VisualStudioDocumentTrackingServiceFactory, " + "Microsoft.VisualStudio.LanguageServices"));
 
-			var containerBuilder = new VsMefContainerBuilder(MEFv3.ComposableCatalog.Create(Resolver.DefaultInstance));
-			var x = containerBuilder.WithCatalog(types);
-			return x;
+			var containerBuilder = new VsMefContainerBuilder(MEFv3.ComposableCatalog.Create(Resolver.DefaultInstance))
+				.WithCatalog(types);
+			return containerBuilder;
 		}
 
 		public VsMefContainerBuilder WithCatalog(IEnumerable<Type> types)
@@ -152,11 +152,6 @@ namespace VSEmbed
 		///</summary>
 		public void Build()
 		{
-			var x = catalog.ToString();
-			var y = catalog.DiscoveredParts.Parts.OrderBy(n => n.Type.ToString());
-
-			var parts = string.Join("\n", y.Select(n => n.Type.ToString()));
-
 			var exportProvider = MEFv3.RuntimeComposition
 				.CreateRuntimeComposition(MEFv3.CompositionConfiguration.Create(catalog).ThrowOnErrors())
 				.CreateExportProviderFactory()

--- a/VSEmbed/VsMefContainerBuilder.cs
+++ b/VSEmbed/VsMefContainerBuilder.cs
@@ -25,32 +25,6 @@ namespace VSEmbed
 			new MEFv3.AttributedPartDiscovery(Resolver.DefaultInstance, isNonPublicSupported: true),
 			new MEFv3.AttributedPartDiscoveryV1(Resolver.DefaultInstance));
 
-		private static readonly string[] UndoComponents =
-		{
-			"BasicUndo"
-		};
-
-		private static readonly string[] EditorComponents = {
-			// JaredPar: Core editor components
-			"Microsoft.VisualStudio.Platform.VSEditor",
-
-			// JaredPar: Must include this because several editor options are actually stored as exported information 
-			// on this DLL.  Including most importantly, the tabsize information
-			"Microsoft.VisualStudio.Text.Logic",
-
-			// JaredPar: Include this DLL to get several more EditorOptions including WordWrapStyle
-			"Microsoft.VisualStudio.Text.UI",
-
-			// JaredPar: Include this DLL to get more EditorOptions values and the core editor
-			"Microsoft.VisualStudio.Text.UI.Wpf",
-
-			// SLaks: Needed for VisualStudioWaitIndicator & probably others
-			"Microsoft.VisualStudio.Editor.Implementation",
-
-			//// SLaks: Needed for IVsHierarchyItemManager, used by peek providers
-			"Microsoft.VisualStudio.Shell.TreeNavigation.HierarchyProvider"
-		};
-
 		private static readonly string[] excludedTypes = {
 			// This uses IVsUIShell, which I haven't implemented, to show dialog boxes.
 			// It also causes strange and fatal AccessViolations.


### PR DESCRIPTION
Since we're eventually only going to support VS2017 we don't need to separate out support for editor, Roslyn and other DLLs. We'll simply list all assemblies we're interested in, get their types, filter their types and then build a MEF catalog off of their types.

After further refactorings we will load all DLLs from the output directory instead of GAC and Program Files.