### PR TITLE
Prevents newlines from being inserted twice

### DIFF
--- a/WpfSendKeys/SendKeys.cs
+++ b/WpfSendKeys/SendKeys.cs
@@ -50,7 +50,8 @@
             element.RaiseEvent(args);
 
             // 3) TextInput
-            SendInputIfNecessary(element, key, modifiers, keyboardDevice);
+            if (!args.Handled) // Return is handled by (Preview)KeyDown, so don't send it twice
+                SendInputIfNecessary(element, key, modifiers, keyboardDevice);
 
             // 4) PreviewKeyUp
             args.RoutedEvent = Keyboard.PreviewKeyUpEvent;

--- a/WpfSendKeys/SendKeys.cs
+++ b/WpfSendKeys/SendKeys.cs
@@ -50,7 +50,7 @@
             element.RaiseEvent(args);
 
             // 3) TextInput
-            if (!args.Handled) // Return is handled by (Preview)KeyDown, so don't send it twice
+            if (!args.Handled) // Newlines are handled by KeyDownEvent, so don't input two newlines
                 SendInputIfNecessary(element, key, modifiers, keyboardDevice);
 
             // 4) PreviewKeyUp


### PR DESCRIPTION
Fixes #26 by not calling `SendInputIfNecessary` if PreviewKeyDown or KeyDown events got handled.